### PR TITLE
Implemented timeout for Http Client

### DIFF
--- a/lib/experiment_client.dart
+++ b/lib/experiment_client.dart
@@ -35,7 +35,7 @@ class ExperimentClient {
     final input = ExperimentFetchInput(
         userId: userId, deviceId: deviceId, userProperties: userProperties);
 
-    await _httpClient.get(input);
+    await _httpClient.get(input, _config?.timeout);
 
     _log(
         '[Experiment] Fetched ${_httpClient.fetchResult.length} experiment(s) for this user!');

--- a/lib/types/experiment_config.dart
+++ b/lib/types/experiment_config.dart
@@ -12,6 +12,8 @@ class ExperimentConfig {
   final bool? automaticExposureTracking;
   final ExperimentExposureTrackingProvider? exposureTrackingProvider;
 
+  Duration get timeout => Duration(milliseconds: fetchTimeoutMillis ?? 5000);
+
   ExperimentConfig(
       {this.debug = false,
       this.instanceName = '\$default_instance',


### PR DESCRIPTION
Since the property `fetchTimeoutMillis` wasn't being used, this PR aims to add the timeout functionality into the SDK, while mantaining backwards compatibility with the existing code.