### PR TITLE
fix(PRODU-70003): fix null safety in experimentVariant frommap

### DIFF
--- a/lib/types/experiment_variant.dart
+++ b/lib/types/experiment_variant.dart
@@ -7,10 +7,16 @@ class ExperimentVariant {
   ExperimentVariant({required this.value, this.payload});
 
   factory ExperimentVariant.fromMap(Map<String, dynamic> map) {
-    final payloadOnMap = map['payload'];
+    // Safe cast for payload - handles non-Map types
+    final rawPayload = map['payload'];
+    final payloadOnMap = rawPayload is Map<String, dynamic> ? rawPayload : null;
 
     return ExperimentVariant(
-        value: map['value'], payload: payloadOnMap['value']);
+      value: (map['value'] as String?) ?? '',
+      payload: payloadOnMap?['value'] is Map<String, dynamic>
+          ? payloadOnMap!['value'] as Map<String, dynamic>
+          : null,
+    );
   }
 
   String toJsonAsString() {


### PR DESCRIPTION
## Quick Info
---

## What does this change?
----
1. **Adds null safety to `ExperimentVariant.fromMap()`** to prevent runtime crashes when loading cached experiment variants with null or missing fields

## Notes
----
### Problem
The SDK was causing runtime errors in production when loading cached experiment variants from local storage:

-------------
## Screenshots
----
N/A - SDK internal fix (no visual changes)